### PR TITLE
Update decorator method to accept meta and options

### DIFF
--- a/decorate.js
+++ b/decorate.js
@@ -4,9 +4,9 @@ const Calibrate = require('./index');
 
 module.exports = function (server, options, next) {
 
-    const decorator = function (res, meta, options){
+    const decorator = function (res, _meta, _options){
 
-        return this.response(Calibrate(res, meta, options));
+        return this.response(Calibrate(res, _meta, _options));
     };
     server.decorate('reply', 'calibrate', decorator);
 

--- a/decorate.js
+++ b/decorate.js
@@ -4,9 +4,9 @@ const Calibrate = require('./index');
 
 module.exports = function (server, options, next) {
 
-    const decorator = function (res){
+    const decorator = function (res, meta, options){
 
-        return this.response(Calibrate(res));
+        return this.response(Calibrate(res, meta, options));
     };
     server.decorate('reply', 'calibrate', decorator);
 


### PR DESCRIPTION
Currently `Calibrate.response` allows for 3 parameters for data, meta and options. However using the decorator method does not allow for the additional information (meta and options). Is there a reason that its not included? This PR updates the method to accept those params.
